### PR TITLE
Remove action name from summary title.

### DIFF
--- a/.github/workflows/bat.yml
+++ b/.github/workflows/bat.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: matlab-actions/setup-matlab@v3
         with:
-          release: latest-including-prerelease
+          release: latest
       - uses: matlab-actions/run-tests@v3
         with:
           source-folder: plugins

--- a/src/buildSummary.ts
+++ b/src/buildSummary.ts
@@ -3,11 +3,9 @@ import * as core from "@actions/core";
 import { join } from "path";
 import { readFileSync, unlinkSync, existsSync } from "fs";
 
-export function addSummary(taskSummaryTableRows: string[][], actionName: string) {
+export function addSummary(taskSummaryTableRows: string[][]) {
     try {
-        core.summary
-            .addHeading("MATLAB Build Results (" + actionName + ") ")
-            .addTable(taskSummaryTableRows);
+        core.summary.addHeading("MATLAB Build Results").addTable(taskSummaryTableRows);
     } catch (e) {
         console.error("An error occurred while adding the build results table to the summary:", e);
     }
@@ -45,7 +43,7 @@ export function interpretSkipReason(skipReason: string) {
     }
 }
 
-export function processAndAddBuildSummary(runnerTemp: string, runId: string, actionName: string) {
+export function processAndAddBuildSummary(runnerTemp: string, runId: string) {
     const header = [
         { data: "MATLAB Task", header: true },
         { data: "Status", header: true },
@@ -73,6 +71,6 @@ export function processAndAddBuildSummary(runnerTemp: string, runId: string, act
                 );
             }
         }
-        addSummary(taskSummaryTable, actionName);
+        addSummary(taskSummaryTable);
     }
 }

--- a/src/buildSummary.unit.test.ts
+++ b/src/buildSummary.unit.test.ts
@@ -78,14 +78,12 @@ describe("summaryGeneration", () => {
             ["MATLAB Task", "Status", "Description", "Duration (HH:mm:ss)"],
             ["Test Task", "🔴 Failed", "A test task", "00:00:10"],
         ];
-        const actionName = "run-build";
-
-        buildSummary.addSummary(mockTableRows, actionName);
+        buildSummary.addSummary(mockTableRows);
 
         expect(core.summary.addHeading).toHaveBeenCalledTimes(1);
         expect(core.summary.addHeading).toHaveBeenNthCalledWith(
             1,
-            expect.stringContaining("MATLAB Build Results (" + actionName + ")"),
+            expect.stringContaining("MATLAB Build Results"),
         );
         expect(core.summary.addTable).toHaveBeenCalledTimes(1);
         expect(core.summary.addTable).toHaveBeenCalledWith(mockTableRows);

--- a/src/testResultsSummary.ts
+++ b/src/testResultsSummary.ts
@@ -62,16 +62,11 @@ export interface TestResultsData {
     Stats: TestStatistics;
 }
 
-export function processAndAddTestSummary(
-    runnerTemp: string,
-    runId: string,
-    actionName: string,
-    workspace: string,
-) {
+export function processAndAddTestSummary(runnerTemp: string, runId: string, workspace: string) {
     const testResultsData = getTestResults(runnerTemp, runId, workspace);
     const coverageResultsData = getCoverageResults(runnerTemp, runId);
     if (testResultsData || coverageResultsData) {
-        addSummary(testResultsData, coverageResultsData, actionName);
+        addSummary(testResultsData, coverageResultsData);
     }
 }
 
@@ -137,7 +132,6 @@ export function getTestResults(
 export function addSummary(
     testResultsData: TestResultsData | null,
     coverageResultsData: CoverageData | null,
-    actionName: string,
 ) {
     try {
         // Add test results table if available
@@ -147,9 +141,7 @@ export function addSummary(
                 ` target="_blank" title="View documentation">ℹ️</a>`;
             const header = getTestHeader(testResultsData.Stats);
 
-            core.summary
-                .addHeading("MATLAB Test Results (" + actionName + ") " + helpLink)
-                .addRaw(header, true);
+            core.summary.addHeading("MATLAB Test Results " + helpLink).addRaw(header, true);
         }
         // Add coverage table if available
         if (coverageResultsData) {

--- a/src/testResultsSummary.unit.test.ts
+++ b/src/testResultsSummary.unit.test.ts
@@ -151,12 +151,12 @@ describe("Artifact Processing Tests", () => {
     it("should write test results data to the GitHub job summary", () => {
         if (testResultsData) {
             const actionName = process.env.GITHUB_ACTION || "";
-            testResultsSummary.addSummary(testResultsData, null, actionName);
+            testResultsSummary.addSummary(testResultsData, null);
 
             expect(core.summary.addHeading).toHaveBeenCalledTimes(2);
             expect(core.summary.addHeading).toHaveBeenNthCalledWith(
                 1,
-                expect.stringContaining("MATLAB Test Results (" + actionName + ")"),
+                expect.stringContaining("MATLAB Test Results "),
             );
             expect(core.summary.addHeading).toHaveBeenNthCalledWith(
                 1,
@@ -355,7 +355,7 @@ describe("Error Handling Tests", () => {
 
         // This should not throw, but should log the error
         expect(() => {
-            testResultsSummary.addSummary(mockTestResultsData, null, "mockAction");
+            testResultsSummary.addSummary(mockTestResultsData, null);
         }).not.toThrow();
 
         // Verify error was logged

--- a/tests/tParallelizableBuildSummaryPlugin.m
+++ b/tests/tParallelizableBuildSummaryPlugin.m
@@ -12,6 +12,7 @@ classdef tParallelizableBuildSummaryPlugin < matlab.unittest.TestCase
         function setupPath(testCase)
             import matlab.unittest.fixtures.PathFixture;
 
+            testCase.assumeFalse(isMATLABReleaseOlderThan("R2026a"));
             testCase.applyFixture(PathFixture(fileparts(fileparts(mfilename("fullpath")))));
         end
     end


### PR DESCRIPTION
Remove the action name from the summary table. I'm also cleaning up the interface, so after this is merged and a release is cut there will be 3 more PRs updating the downstream actions.