### PR TITLE
Add CI job summary opt-out support and scope artifacts by action name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,9 +98,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -269,9 +269,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1241,9 +1241,9 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "15.3.2",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
-            "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+            "version": "15.4.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+            "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -1279,9 +1279,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1943,9 +1943,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.24",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-            "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+            "version": "2.10.27",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+            "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2378,9 +2378,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.345",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
-            "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
+            "version": "1.5.351",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.351.tgz",
+            "integrity": "sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==",
             "dev": true,
             "license": "ISC"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1943,9 +1943,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.23",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
-            "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+            "version": "2.10.24",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+            "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2378,9 +2378,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.344",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-            "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+            "version": "1.5.345",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
+            "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
             "dev": true,
             "license": "ISC"
         },
@@ -4931,9 +4931,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-            "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"

--- a/plugins/+buildframework/BuildSummaryPlugin.m
+++ b/plugins/+buildframework/BuildSummaryPlugin.m
@@ -10,13 +10,15 @@ classdef BuildSummaryPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
         function runTaskGraph(plugin, pluginData)
             runTaskGraph@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
 
-            [fID, msg] = fopen(fullfile(getenv("RUNNER_TEMP") ,"buildSummary" + getenv("GITHUB_RUN_ID") + ".json"), "w");
-            if fID == -1
-                warning("buildframework:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
-            else
-                closeFile = onCleanup(@()fclose(fID));
-                s = jsonencode(plugin.TaskDetails);
-                fprintf(fID, "%s",s);
+            if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true")
+                [fID, msg] = fopen(fullfile(getenv("RUNNER_TEMP"), "buildSummary" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json"), "w");
+                if fID == -1
+                    warning("buildframework:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
+                else
+                    closeFile = onCleanup(@()fclose(fID));
+                    s = jsonencode(plugin.TaskDetails);
+                    fprintf(fID, "%s",s);
+                end
             end
         end
 

--- a/plugins/+buildframework/BuildSummaryPlugin.m
+++ b/plugins/+buildframework/BuildSummaryPlugin.m
@@ -1,6 +1,6 @@
 classdef BuildSummaryPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
-%   Copyright 2024-25 The MathWorks, Inc.
+%   Copyright 2024-26 The MathWorks, Inc.
 
     properties (Access=private)
         TaskDetails = {};

--- a/plugins/+buildframework/ParallelizableBuildSummaryPlugin.m
+++ b/plugins/+buildframework/ParallelizableBuildSummaryPlugin.m
@@ -34,14 +34,16 @@ classdef ParallelizableBuildSummaryPlugin < matlab.buildtool.plugins.BuildRunner
             end
 
             % Write to file
-            folder = fileparts(plugin.TempFolder);
-            [fID, msg] = fopen(fullfile(folder, "buildSummary" + getenv("GITHUB_RUN_ID") + ".json"), "w");
-            if fID == -1
-                warning("buildframework:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
-            else
-                closeFile = onCleanup(@()fclose(fID));
-                s = jsonencode(taskDetails);
-                fprintf(fID, "%s", s);
+            if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true")
+                folder = fileparts(plugin.TempFolder);
+                [fID, msg] = fopen(fullfile(folder, "buildSummary" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json"), "w");
+                if fID == -1
+                    warning("buildframework:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
+                else
+                    closeFile = onCleanup(@()fclose(fID));
+                    s = jsonencode(taskDetails);
+                    fprintf(fID, "%s", s);
+                end
             end
         end
 

--- a/plugins/+testframework/TestResultsSummaryPlugin.m
+++ b/plugins/+testframework/TestResultsSummaryPlugin.m
@@ -3,37 +3,39 @@ classdef TestResultsSummaryPlugin < matlab.unittest.plugins.TestRunnerPlugin
     
     methods (Access=protected)
         function reportFinalizedSuite(plugin, pluginData)
-            % Checkout MATLAB Test license
-            license('checkout', 'matlab_test');
+            if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true")
+                % Checkout MATLAB Test license
+                license('checkout', 'matlab_test');
 
-            testDetails = struct([]);
-            for idx = 1:numel(pluginData.TestResult)
-                testDetails(idx).TestResult.Duration = pluginData.TestResult(idx).Duration;
-                if isfield(pluginData.TestResult(idx).Details, "DiagnosticRecord") && ~isempty(pluginData.TestResult(idx).Details.DiagnosticRecord)
-                    testDetails(idx).TestResult.Details.DiagnosticRecord.Event = pluginData.TestResult(idx).Details.DiagnosticRecord.Event;
-                    testDetails(idx).TestResult.Details.DiagnosticRecord.Report = pluginData.TestResult(idx).Details.DiagnosticRecord.Report;
-                else
-                    testDetails(idx).TestResult.Details = struct();
+                testDetails = struct([]);
+                for idx = 1:numel(pluginData.TestResult)
+                    testDetails(idx).TestResult.Duration = pluginData.TestResult(idx).Duration;
+                    if isfield(pluginData.TestResult(idx).Details, "DiagnosticRecord") && ~isempty(pluginData.TestResult(idx).Details.DiagnosticRecord)
+                        testDetails(idx).TestResult.Details.DiagnosticRecord.Event = pluginData.TestResult(idx).Details.DiagnosticRecord.Event;
+                        testDetails(idx).TestResult.Details.DiagnosticRecord.Report = pluginData.TestResult(idx).Details.DiagnosticRecord.Report;
+                    else
+                        testDetails(idx).TestResult.Details = struct();
+                    end
+                    testDetails(idx).TestResult.Name = pluginData.TestResult(idx).Name;
+                    testDetails(idx).TestResult.Passed = pluginData.TestResult(idx).Passed;
+                    testDetails(idx).TestResult.Failed = pluginData.TestResult(idx).Failed;
+                    testDetails(idx).TestResult.Incomplete = pluginData.TestResult(idx).Incomplete;
+                    testDetails(idx).BaseFolder = pluginData.TestSuite(idx).BaseFolder;
                 end
-                testDetails(idx).TestResult.Name = pluginData.TestResult(idx).Name;
-                testDetails(idx).TestResult.Passed = pluginData.TestResult(idx).Passed;
-                testDetails(idx).TestResult.Failed = pluginData.TestResult(idx).Failed;
-                testDetails(idx).TestResult.Incomplete = pluginData.TestResult(idx).Incomplete;
-                testDetails(idx).BaseFolder = pluginData.TestSuite(idx).BaseFolder;
-            end
 
-            try
-                jsonTestResults = jsonencode(testDetails, "PrettyPrint", true);
-                testArtifactFile = fullfile(getenv("RUNNER_TEMP"), "matlabTestResults_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json");
-                [fID, msg] = fopen(testArtifactFile, "w");
-                if fID == -1
-                    warning("testframework:TestResultsSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the table of test results. (Cause: %s)", msg);
-                else
-                    closeFile = onCleanup(@()fclose(fID));
-                    fprintf(fID, '%s', jsonTestResults);
+                try
+                    jsonTestResults = jsonencode(testDetails, "PrettyPrint", true);
+                    testArtifactFile = fullfile(getenv("RUNNER_TEMP"), "matlabTestResults" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json");
+                    [fID, msg] = fopen(testArtifactFile, "w");
+                    if fID == -1
+                        warning("testframework:TestResultsSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the table of test results. (Cause: %s)", msg);
+                    else
+                        closeFile = onCleanup(@()fclose(fID));
+                        fprintf(fID, '%s', jsonTestResults);
+                    end
+                catch e
+                    warning("testframework:TestResultsSummaryPlugin:UnableToJsonEncode","Unable to jsonencode test results data. (Cause: %s)", e.message);
                 end
-            catch e
-                warning("testframework:TestResultsSummaryPlugin:UnableToJsonEncode","Unable to jsonencode test results data. (Cause: %s)", e.message);
             end
 
             % Invoke the superclass method

--- a/src/buildSummary.ts
+++ b/src/buildSummary.ts
@@ -1,7 +1,7 @@
-// Copyright 2024-25 The MathWorks, Inc.
+// Copyright 2024-26 The MathWorks, Inc.
 import * as core from "@actions/core";
 import { join } from "path";
-import { readFileSync, unlinkSync, existsSync } from "fs";
+import { readFileSync, unlinkSync, readdirSync } from "fs";
 
 export function addSummary(taskSummaryTableRows: string[][]) {
     try {
@@ -43,7 +43,27 @@ export function interpretSkipReason(skipReason: string) {
     }
 }
 
-export function processAndAddBuildSummary(runnerTemp: string, runId: string) {
+export function processAndAddBuildSummary(runnerTemp: string, actionName: string) {
+    const filePrefix = `buildSummary${actionName}_`;
+    const fileSuffix = `.json`;
+
+    let buildSummaryFiles: string[] = [];
+    try {
+        buildSummaryFiles = readdirSync(runnerTemp)
+            .filter((file) => file.startsWith(filePrefix) && file.endsWith(fileSuffix))
+            .sort();
+    } catch (e) {
+        console.error(
+            `An error occurred while finding build summary file(s) in directory ${runnerTemp}:`,
+            e,
+        );
+        return;
+    }
+
+    if (buildSummaryFiles.length === 0) {
+        return;
+    }
+
     const header = [
         { data: "MATLAB Task", header: true },
         { data: "Status", header: true },
@@ -51,16 +71,15 @@ export function processAndAddBuildSummary(runnerTemp: string, runId: string) {
         { data: "Duration (HH:mm:ss)", header: true },
     ];
 
-    const filePath: string = join(runnerTemp, `buildSummary${runId}.json`);
-    let taskSummaryTable;
-    if (existsSync(filePath)) {
+    for (const fileName of buildSummaryFiles) {
+        const filePath = join(runnerTemp, fileName);
         try {
             const buildSummary = readFileSync(filePath, { encoding: "utf8" });
             const rows = getSummaryRows(buildSummary);
-            taskSummaryTable = [header, ...rows];
+            const taskSummaryTable = [header, ...rows];
+            addSummary(taskSummaryTable);
         } catch (e) {
             console.error("An error occurred while reading the build summary file:", e);
-            return;
         } finally {
             try {
                 unlinkSync(filePath);
@@ -71,6 +90,5 @@ export function processAndAddBuildSummary(runnerTemp: string, runId: string) {
                 );
             }
         }
-        addSummary(taskSummaryTable);
     }
 }

--- a/src/buildSummary.unit.test.ts
+++ b/src/buildSummary.unit.test.ts
@@ -1,6 +1,8 @@
 // Copyright 2024-26 The MathWorks, Inc.
 
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import * as path from "path";
+import * as nodeFs from "fs";
 
 jest.unstable_mockModule("@actions/core", () => ({
     summary: {
@@ -10,17 +12,56 @@ jest.unstable_mockModule("@actions/core", () => ({
     },
 }));
 
+// Mock fs, passing through real implementations except unlinkSync
+const mockUnlinkSync = jest.fn();
+jest.unstable_mockModule("fs", () => ({
+    readFileSync: nodeFs.readFileSync,
+    existsSync: nodeFs.existsSync,
+    writeFileSync: nodeFs.writeFileSync,
+    readdirSync: nodeFs.readdirSync,
+    unlinkSync: mockUnlinkSync,
+}));
+
 const core = await import("@actions/core");
+const fs = await import("fs");
 const buildSummary = await import("./buildSummary.js");
 
+const runnerTemp = path.join(import.meta.dirname, "..");
+
+function safeDelete(filePath: string) {
+    try {
+        nodeFs.unlinkSync(filePath);
+    } catch (e) {
+        /* ignore */
+    }
+}
+
+const validBuildData = JSON.stringify([
+    {
+        name: "compile",
+        failed: false,
+        skipped: false,
+        description: "Compile source",
+        duration: "00:00:10",
+    },
+    {
+        name: "test",
+        failed: true,
+        skipped: false,
+        description: "Run tests",
+        duration: "00:00:25",
+    },
+]);
+
 beforeEach(() => {
-    (core.summary.addTable as jest.Mock).mockReturnThis();
-    (core.summary.addHeading as jest.Mock).mockReturnThis();
-    (core.summary.write as jest.Mock).mockReturnThis();
+    (core.summary.addTable as jest.Mock).mockClear();
+    (core.summary.addHeading as jest.Mock).mockClear();
+    (core.summary.write as jest.Mock).mockClear();
+    mockUnlinkSync.mockReset();
 });
 
-describe("summaryGeneration", () => {
-    it("should process and return summary rows for valid JSON with different task statuses", () => {
+describe("getSummaryRows", () => {
+    it("should return correct rows for different task statuses", () => {
         const mockBuildSummary = JSON.stringify([
             {
                 name: "Task 1",
@@ -73,19 +114,151 @@ describe("summaryGeneration", () => {
         ]);
     });
 
-    it("writes the summary correctly", () => {
-        const mockTableRows = [
-            ["MATLAB Task", "Status", "Description", "Duration (HH:mm:ss)"],
-            ["Test Task", "🔴 Failed", "A test task", "00:00:10"],
-        ];
-        buildSummary.addSummary(mockTableRows);
+    it("should return empty array for empty JSON array", () => {
+        const result = buildSummary.getSummaryRows("[]");
+        expect(result).toEqual([]);
+    });
+});
 
-        expect(core.summary.addHeading).toHaveBeenCalledTimes(1);
-        expect(core.summary.addHeading).toHaveBeenNthCalledWith(
-            1,
-            expect.stringContaining("MATLAB Build Results"),
+describe("processAndAddBuildSummary", () => {
+    it("should discover and process files matching the actionName", () => {
+        const filePath = path.join(runnerTemp, "buildSummarymy-action_20260509_100000_001.json");
+        fs.writeFileSync(filePath, validBuildData);
+
+        try {
+            buildSummary.processAndAddBuildSummary(runnerTemp, "my-action");
+
+            expect(core.summary.addHeading).toHaveBeenCalledWith("MATLAB Build Results");
+            expect(core.summary.addTable).toHaveBeenCalledTimes(1);
+
+            const tableArg = (core.summary.addTable as jest.Mock).mock.calls[0][0] as any[][];
+            expect(tableArg[1]).toEqual(["compile", "🟢 Successful", "Compile source", "00:00:10"]);
+            expect(tableArg[2]).toEqual(["test", "🔴 Failed", "Run tests", "00:00:25"]);
+        } finally {
+            safeDelete(filePath);
+        }
+    });
+
+    it("should ignore files for a different actionName", () => {
+        const matchingFile = path.join(
+            runnerTemp,
+            "buildSummarymy-action_20260509_100000_001.json",
         );
-        expect(core.summary.addTable).toHaveBeenCalledTimes(1);
-        expect(core.summary.addTable).toHaveBeenCalledWith(mockTableRows);
+        const nonMatchingFile = path.join(
+            runnerTemp,
+            "buildSummaryother-action_20260509_100000_001.json",
+        );
+        fs.writeFileSync(matchingFile, validBuildData);
+        fs.writeFileSync(nonMatchingFile, validBuildData);
+
+        try {
+            buildSummary.processAndAddBuildSummary(runnerTemp, "my-action");
+
+            expect(core.summary.addTable).toHaveBeenCalledTimes(1);
+            expect(mockUnlinkSync).toHaveBeenCalledWith(matchingFile);
+            expect(mockUnlinkSync).not.toHaveBeenCalledWith(nonMatchingFile);
+        } finally {
+            safeDelete(matchingFile);
+            safeDelete(nonMatchingFile);
+        }
+    });
+
+    it("should not add summary when no matching files exist", () => {
+        buildSummary.processAndAddBuildSummary(runnerTemp, "nonexistent-action");
+
+        expect(core.summary.addHeading).not.toHaveBeenCalled();
+        expect(core.summary.addTable).not.toHaveBeenCalled();
+    });
+
+    it("should handle non-existent directory gracefully", () => {
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+        buildSummary.processAndAddBuildSummary("/nonexistent/directory/path", "my-action");
+
+        expect(core.summary.addTable).not.toHaveBeenCalled();
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "An error occurred while finding build summary file(s) in directory",
+            ),
+            expect.any(Error),
+        );
+        consoleSpy.mockRestore();
+    });
+
+    it("should handle invalid JSON gracefully", () => {
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        const filePath = path.join(runnerTemp, "buildSummarymy-action_20260509_100000_002.json");
+        fs.writeFileSync(filePath, "{ invalid json");
+
+        try {
+            buildSummary.processAndAddBuildSummary(runnerTemp, "my-action");
+
+            expect(core.summary.addTable).not.toHaveBeenCalled();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                "An error occurred while reading the build summary file:",
+                expect.any(Error),
+            );
+        } finally {
+            safeDelete(filePath);
+            consoleSpy.mockRestore();
+        }
+    });
+
+    it("should delete files after processing", () => {
+        const filePath = path.join(runnerTemp, "buildSummarymy-action_20260509_100000_003.json");
+        fs.writeFileSync(filePath, validBuildData);
+
+        try {
+            buildSummary.processAndAddBuildSummary(runnerTemp, "my-action");
+
+            expect(mockUnlinkSync).toHaveBeenCalledWith(filePath);
+        } finally {
+            safeDelete(filePath);
+        }
+    });
+
+    it("should handle file deletion errors gracefully", () => {
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        mockUnlinkSync.mockImplementationOnce(() => {
+            throw new Error("Permission denied");
+        });
+
+        const filePath = path.join(runnerTemp, "buildSummarymy-action_20260509_100000_004.json");
+        fs.writeFileSync(filePath, validBuildData);
+
+        try {
+            buildSummary.processAndAddBuildSummary(runnerTemp, "my-action");
+
+            expect(core.summary.addTable).toHaveBeenCalledTimes(1);
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    "An error occurred while trying to delete the build summary file",
+                ),
+                expect.any(Error),
+            );
+        } finally {
+            mockUnlinkSync.mockReset();
+            safeDelete(filePath);
+            consoleSpy.mockRestore();
+        }
+    });
+
+    it("should process multiple build summary files", () => {
+        const file1 = path.join(runnerTemp, "buildSummarymy-action_20260509_100000_005.json");
+        const file2 = path.join(runnerTemp, "buildSummarymy-action_20260509_100000_006.json");
+        fs.writeFileSync(file1, validBuildData);
+        fs.writeFileSync(file2, validBuildData);
+
+        try {
+            buildSummary.processAndAddBuildSummary(runnerTemp, "my-action");
+
+            expect(core.summary.addHeading).toHaveBeenCalledTimes(2);
+            expect(core.summary.addTable).toHaveBeenCalledTimes(2);
+            expect(mockUnlinkSync).toHaveBeenCalledWith(file1);
+            expect(mockUnlinkSync).toHaveBeenCalledWith(file2);
+        } finally {
+            safeDelete(file1);
+            safeDelete(file2);
+        }
     });
 });

--- a/src/buildSummary.unit.test.ts
+++ b/src/buildSummary.unit.test.ts
@@ -176,11 +176,9 @@ describe("processAndAddBuildSummary", () => {
         buildSummary.processAndAddBuildSummary("/nonexistent/directory/path", "my-action");
 
         expect(core.summary.addTable).not.toHaveBeenCalled();
-        expect(consoleSpy).toHaveBeenCalledWith(
-            expect.stringContaining(
-                "An error occurred while finding build summary file(s) in directory",
-            ),
-            expect.any(Error),
+        expect(consoleSpy).toHaveBeenCalled();
+        expect(consoleSpy.mock.calls[0][0] as string).toContain(
+            "An error occurred while finding build summary file(s) in directory",
         );
         consoleSpy.mockRestore();
     });

--- a/src/testResultsSummary.ts
+++ b/src/testResultsSummary.ts
@@ -68,7 +68,12 @@ export interface TestResultsData {
     OverallStats: TestStatistics;
 }
 
-export function processAndAddTestSummary(runnerTemp: string, runId: string, actionName: string, workspace: string) {
+export function processAndAddTestSummary(
+    runnerTemp: string,
+    runId: string,
+    actionName: string,
+    workspace: string,
+) {
     const testResultsData = getTestResults(runnerTemp, actionName, workspace);
     const coverageResultsData = getCoverageResults(runnerTemp, runId);
     if (testResultsData || coverageResultsData) {
@@ -76,7 +81,11 @@ export function processAndAddTestSummary(runnerTemp: string, runId: string, acti
     }
 }
 
-export function getTestResults(runnerTemp: string, actionName: string, workspace: string): TestResultsData | null {
+export function getTestResults(
+    runnerTemp: string,
+    actionName: string,
+    workspace: string,
+): TestResultsData | null {
     let testResultsData = null;
     const filePrefix = `matlabTestResults${actionName}_`;
     const fileSuffix = `.json`;

--- a/src/testResultsSummary.ts
+++ b/src/testResultsSummary.ts
@@ -68,17 +68,17 @@ export interface TestResultsData {
     OverallStats: TestStatistics;
 }
 
-export function processAndAddTestSummary(runnerTemp: string, runId: string, workspace: string) {
-    const testResultsData = getTestResults(runnerTemp, workspace);
+export function processAndAddTestSummary(runnerTemp: string, runId: string, actionName: string, workspace: string) {
+    const testResultsData = getTestResults(runnerTemp, actionName, workspace);
     const coverageResultsData = getCoverageResults(runnerTemp, runId);
     if (testResultsData || coverageResultsData) {
         addSummary(testResultsData, coverageResultsData);
     }
 }
 
-export function getTestResults(runnerTemp: string, workspace: string): TestResultsData | null {
+export function getTestResults(runnerTemp: string, actionName: string, workspace: string): TestResultsData | null {
     let testResultsData = null;
-    const filePrefix = `matlabTestResults_`;
+    const filePrefix = `matlabTestResults${actionName}_`;
     const fileSuffix = `.json`;
 
     // Find all test result files matching the pattern

--- a/src/testResultsSummary.unit.test.ts
+++ b/src/testResultsSummary.unit.test.ts
@@ -37,6 +37,55 @@ const fs = await import("fs");
 const testResultsSummary = await import("./testResultsSummary.js");
 const { MatlabTestStatus } = testResultsSummary;
 
+function getOSInfo() {
+    const platform = os.platform().toLowerCase();
+    if (platform.includes("win") && !platform.includes("darwin"))
+        return { osName: "windows", workspaceParent: "C:\\" };
+    if (platform.includes("linux") || platform.includes("unix") || platform.includes("aix"))
+        return { osName: "linux", workspaceParent: "/home/user/" };
+    if (platform.includes("darwin")) return { osName: "mac", workspaceParent: "/Users/username/" };
+    throw new Error(`Unsupported OS: ${platform}`);
+}
+
+function safeDelete(filePath: string) {
+    try {
+        nodeFs.unlinkSync(filePath);
+    } catch (e) {
+        /* ignore */
+    }
+}
+
+const runnerTemp = path.join(import.meta.dirname, "..");
+const osInfo = getOSInfo();
+const workspace = path.join(osInfo.workspaceParent, "workspace");
+
+function getTestDataSource(testFolder: string, fileName: string) {
+    return path.join(
+        import.meta.dirname,
+        "test-data",
+        "testResultsArtifacts",
+        testFolder,
+        osInfo.osName,
+        fileName,
+    );
+}
+
+function copyTestDataAndRun(
+    testFolder: string,
+    sourceFileName: string,
+    destFileName: string,
+    actionName = "",
+) {
+    const sourceFilePath = getTestDataSource(testFolder, sourceFileName);
+    const destPath = path.join(runnerTemp, destFileName);
+    fs.copyFileSync(sourceFilePath, destPath);
+
+    const result = testResultsSummary.getTestResults(runnerTemp, actionName, workspace);
+
+    safeDelete(destPath);
+    return result;
+}
+
 describe("Artifact Processing Tests", () => {
     // Shared test data
     let testResultsData: TestResultsData | null;
@@ -45,59 +94,27 @@ describe("Artifact Processing Tests", () => {
     let stats: TestStatistics;
 
     beforeAll(() => {
-        const runnerTemp = path.join(import.meta.dirname, "..");
-        const osInfo = getOSInfo();
-        const workspace = path.join(osInfo.workspaceParent, "workspace");
+        const sourceFilePath = getTestDataSource(
+            "t1",
+            "matlabTestResults_20250101_100000_001.json",
+        );
+        const destPath = path.join(runnerTemp, "matlabTestResults_20250101_100000_001.json");
 
-        copyTestDataFile(osInfo.osName, runnerTemp);
+        try {
+            fs.copyFileSync(sourceFilePath, destPath);
+        } catch (err) {
+            console.error("Error copying test-data:", err);
+        }
 
-        testResultsData = testResultsSummary.getTestResults(runnerTemp, workspace);
+        testResultsData = testResultsSummary.getTestResults(runnerTemp, "", workspace);
         if (testResultsData) {
             testSession = testResultsData.TestSessions[0];
             testResults = testSession.TestResults;
             stats = testResultsData.OverallStats;
         }
 
-        // Clean up test file since unlinkSync is mocked
-        const testFile = path.join(runnerTemp, "matlabTestResults_20250101_100000_001.json");
-        try {
-            nodeFs.unlinkSync(testFile);
-        } catch (e) {
-            /* ignore */
-        }
+        safeDelete(destPath);
     });
-
-    function getOSInfo() {
-        const platform = os.platform().toLowerCase();
-        if (platform.includes("win") && !platform.includes("darwin"))
-            return { osName: "windows", workspaceParent: "C:\\" };
-        if (platform.includes("linux") || platform.includes("unix") || platform.includes("aix"))
-            return { osName: "linux", workspaceParent: "/home/user/" };
-        if (platform.includes("darwin"))
-            return { osName: "mac", workspaceParent: "/Users/username/" };
-        throw new Error(`Unsupported OS: ${platform}`);
-    }
-
-    function copyTestDataFile(osName: string, runnerTemp: string) {
-        const sourceFilePath = path.join(
-            import.meta.dirname,
-            "test-data",
-            "testResultsArtifacts",
-            "t1",
-            osName,
-            "matlabTestResults_20250101_100000_001.json",
-        );
-        const destinationFilePath = path.join(
-            runnerTemp,
-            "matlabTestResults_20250101_100000_001.json",
-        );
-
-        try {
-            fs.copyFileSync(sourceFilePath, destinationFilePath);
-        } catch (err) {
-            console.error("Error copying test-data:", err);
-        }
-    }
 
     it("should return correct test results data for valid JSON", () => {
         expect(testResultsData).toBeDefined();
@@ -389,28 +406,9 @@ describe("HTML Structure Tests", () => {
 describe("Multiple Sessions Tests", () => {
     let testResultsData: TestResultsData | null;
 
-    function getOSInfo() {
-        const platform = os.platform().toLowerCase();
-        if (platform.includes("win") && !platform.includes("darwin"))
-            return { osName: "windows", workspaceParent: "C:\\" };
-        if (platform.includes("linux") || platform.includes("unix") || platform.includes("aix"))
-            return { osName: "linux", workspaceParent: "/home/user/" };
-        if (platform.includes("darwin"))
-            return { osName: "mac", workspaceParent: "/Users/username/" };
-        throw new Error(`Unsupported OS: ${platform}`);
-    }
-
     beforeAll(() => {
-        const runnerTemp = path.join(import.meta.dirname, "..");
-        const osInfo = getOSInfo();
-        const workspace = path.join(osInfo.workspaceParent, "workspace");
-
-        const sourceFilePath = path.join(
-            import.meta.dirname,
-            "test-data",
-            "testResultsArtifacts",
+        const sourceFilePath = getTestDataSource(
             "t1",
-            osInfo.osName,
             "matlabTestResults_20250101_100000_001.json",
         );
 
@@ -425,19 +423,10 @@ describe("Multiple Sessions Tests", () => {
             console.error("Error copying test-data:", err);
         }
 
-        testResultsData = testResultsSummary.getTestResults(runnerTemp, workspace);
+        testResultsData = testResultsSummary.getTestResults(runnerTemp, "", workspace);
 
-        // Clean up test files since unlinkSync is mocked
-        try {
-            nodeFs.unlinkSync(dest1);
-        } catch (e) {
-            /* ignore */
-        }
-        try {
-            nodeFs.unlinkSync(dest2);
-        } catch (e) {
-            /* ignore */
-        }
+        safeDelete(dest1);
+        safeDelete(dest2);
     });
 
     it("should return multiple test sessions", () => {
@@ -534,19 +523,83 @@ describe("Multiple Sessions Tests", () => {
 describe("No Results Tests", () => {
     it("should return null when no matching files exist", () => {
         const emptyDir = path.join(import.meta.dirname, "test-data");
-        const result = testResultsSummary.getTestResults(emptyDir, "");
+        const result = testResultsSummary.getTestResults(emptyDir, "", workspace);
         expect(result).toBeNull();
     });
 
     it("should return null when directory does not exist", () => {
         const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-        const result = testResultsSummary.getTestResults("/nonexistent/directory/path", "");
+        const result = testResultsSummary.getTestResults(
+            "/nonexistent/directory/path",
+            "",
+            workspace,
+        );
         expect(result).toBeNull();
         expect(consoleSpy).toHaveBeenCalled();
         expect(consoleSpy.mock.calls[0][0] as string).toContain(
             "An error occurred while finding test results summary file(s) in directory",
         );
         consoleSpy.mockRestore();
+    });
+});
+
+describe("actionName Filtering Tests", () => {
+    it("should only pick up files matching the given actionName", () => {
+        const sourceFilePath = getTestDataSource(
+            "t1",
+            "matlabTestResults_20250101_100000_001.json",
+        );
+
+        const matchingFile = path.join(
+            runnerTemp,
+            "matlabTestResultsmy-action_20250101_100000_001.json",
+        );
+        const nonMatchingFile = path.join(
+            runnerTemp,
+            "matlabTestResultsother-action_20250101_100000_001.json",
+        );
+
+        try {
+            fs.copyFileSync(sourceFilePath, matchingFile);
+            fs.copyFileSync(sourceFilePath, nonMatchingFile);
+
+            const result = testResultsSummary.getTestResults(runnerTemp, "my-action", workspace);
+
+            expect(result).not.toBeNull();
+            expect(result!.TestSessions.length).toBe(1);
+            expect(result!.TestSessions[0].FileName).toBe(
+                "matlabTestResultsmy-action_20250101_100000_001.json",
+            );
+        } finally {
+            safeDelete(matchingFile);
+            safeDelete(nonMatchingFile);
+        }
+    });
+
+    it("should return null when no files match the actionName", () => {
+        const sourceFilePath = getTestDataSource(
+            "t1",
+            "matlabTestResults_20250101_100000_001.json",
+        );
+
+        const nonMatchingFile = path.join(
+            runnerTemp,
+            "matlabTestResultsother-action_20250101_100000_001.json",
+        );
+
+        try {
+            fs.copyFileSync(sourceFilePath, nonMatchingFile);
+
+            const result = testResultsSummary.getTestResults(
+                runnerTemp,
+                "nonexistent-action",
+                workspace,
+            );
+
+            expect(result).toBeNull();
+        } finally {
+            safeDelete(nonMatchingFile);
+        }
     });
 });
 
@@ -595,19 +648,15 @@ describe("Error Handling Tests", () => {
     it("should handle JSON parsing errors gracefully", () => {
         const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-        const runnerTemp = path.join(import.meta.dirname, "..");
-
-        // Create a file with invalid JSON matching the new naming pattern
         const invalidJsonPath = path.join(runnerTemp, "matlabTestResults_20250101_100000_097.json");
         fs.writeFileSync(invalidJsonPath, "{ invalid json content");
 
         try {
-            const result = testResultsSummary.getTestResults(runnerTemp, "");
+            const result = testResultsSummary.getTestResults(runnerTemp, "", "");
             expect(result).not.toBeNull();
             expect(result!.TestSessions.length).toBe(0);
             expect(result!.OverallStats.Total).toBe(0);
 
-            // Verify error was logged
             expect(consoleSpy).toHaveBeenCalledWith(
                 expect.stringContaining(
                     "An error occurred while reading the test results summary file",
@@ -615,10 +664,7 @@ describe("Error Handling Tests", () => {
                 expect.any(Error),
             );
         } finally {
-            // Clean up
-            if (nodeFs.existsSync(invalidJsonPath)) {
-                nodeFs.unlinkSync(invalidJsonPath);
-            }
+            safeDelete(invalidJsonPath);
             consoleSpy.mockRestore();
         }
     });
@@ -626,26 +672,20 @@ describe("Error Handling Tests", () => {
     it("should handle file deletion errors gracefully", () => {
         const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-        // Set up the mock to throw an error for this test
         mockUnlinkSync.mockImplementationOnce(() => {
             throw new Error("Permission denied - cannot delete file");
         });
 
-        const runnerTemp = path.join(import.meta.dirname, "..");
-
-        // Create a valid JSON file matching the new naming pattern
         const validJsonPath = path.join(runnerTemp, "matlabTestResults_20250101_100000_096.json");
-        fs.writeFileSync(validJsonPath, "[]"); // Empty array - valid JSON
+        fs.writeFileSync(validJsonPath, "[]");
 
         try {
-            const result = testResultsSummary.getTestResults(runnerTemp, "");
+            const result = testResultsSummary.getTestResults(runnerTemp, "", "");
 
-            // Should still return results even if deletion fails
             expect(result).not.toBeNull();
             expect(result!.TestSessions.length).toBe(1);
             expect(result!.TestSessions[0].TestResults).toEqual([]);
 
-            // Verify deletion error was logged
             expect(consoleSpy).toHaveBeenCalledWith(
                 expect.stringContaining(
                     "An error occurred while trying to delete the test results summary file",
@@ -653,19 +693,11 @@ describe("Error Handling Tests", () => {
                 expect.any(Error),
             );
 
-            // Verify unlinkSync was called
             expect(mockUnlinkSync).toHaveBeenCalledWith(validJsonPath);
         } finally {
-            // Clean up
             mockUnlinkSync.mockReset();
             consoleSpy.mockRestore();
-
-            // Clean up the test file using real fs
-            try {
-                nodeFs.unlinkSync(validJsonPath);
-            } catch (e) {
-                // Ignore cleanup errors
-            }
+            safeDelete(validJsonPath);
         }
     });
 });
@@ -677,45 +709,6 @@ describe("Data Processing Edge Cases", () => {
             ? TC
             : never
         : never;
-
-    function getOSInfoHelper() {
-        const platform = os.platform().toLowerCase();
-        if (platform.includes("win") && !platform.includes("darwin"))
-            return { osName: "windows", workspaceParent: "C:\\" };
-        if (platform.includes("linux") || platform.includes("unix") || platform.includes("aix"))
-            return { osName: "linux", workspaceParent: "/home/user/" };
-        if (platform.includes("darwin"))
-            return { osName: "mac", workspaceParent: "/Users/username/" };
-        throw new Error(`Unsupported OS: ${platform}`);
-    }
-
-    function copyTestDataAndRun(testFolder: string, sourceFileName: string, destFileName: string) {
-        const runnerTemp = path.join(import.meta.dirname, "..");
-        const osInfo = getOSInfoHelper();
-        const workspace = path.join(osInfo.workspaceParent, "workspace");
-
-        const sourceFilePath = path.join(
-            import.meta.dirname,
-            "test-data",
-            "testResultsArtifacts",
-            testFolder,
-            osInfo.osName,
-            sourceFileName,
-        );
-        const destPath = path.join(runnerTemp, destFileName);
-        fs.copyFileSync(sourceFilePath, destPath);
-
-        const result = testResultsSummary.getTestResults(runnerTemp, workspace);
-
-        // Clean up since unlinkSync is mocked
-        try {
-            nodeFs.unlinkSync(destPath);
-        } catch (e) {
-            /* ignore */
-        }
-
-        return result;
-    }
 
     it("should handle single object JSON (non-array test artifact)", () => {
         const result = copyTestDataAndRun(

--- a/tests/tParallelizableBuildSummaryPlugin.m
+++ b/tests/tParallelizableBuildSummaryPlugin.m
@@ -20,9 +20,12 @@ classdef tParallelizableBuildSummaryPlugin < matlab.unittest.TestCase
     methods (TestMethodSetup)
         function createPlugin(testCase)
             import matlab.unittest.fixtures.WorkingFolderFixture;
-            
+            import matlab.unittest.fixtures.EnvironmentVariableFixture;
+
             testCase.applyFixture(WorkingFolderFixture);
             testCase.TempFolder = pwd();
+            testCase.applyFixture(EnvironmentVariableFixture("MW_GENERATE_JOB_SUMMARY", "true"));
+            testCase.applyFixture(EnvironmentVariableFixture("GITHUB_ACTION", "my-action"));
 
             testCase.Plugin = ParallelizableBuildSummaryPlugin(TempFolder=testCase.TempFolder);
             testCase.Runner = matlab.buildtool.BuildRunner.withNoPlugins();
@@ -38,8 +41,8 @@ classdef tParallelizableBuildSummaryPlugin < matlab.unittest.TestCase
 
             testCase.Runner.run(plan, ["t1", "t2"]);
 
-            name = "buildSummary" + getenv("GITHUB_RUN_ID") + ".json";
-            testCase.verifyTrue(isfile(fullfile(testCase.TempFolder, name)));
+            f = findBuildSummaryFile(testCase.TempFolder);
+            testCase.verifyNotEmpty(f);
         end
 
         function runningBuildCreatesSummaryArtifactWithExpectedTasks(testCase)
@@ -49,9 +52,8 @@ classdef tParallelizableBuildSummaryPlugin < matlab.unittest.TestCase
 
             testCase.Runner.run(plan, ["t1", "t2"]);
 
-            name = "buildSummary" + getenv("GITHUB_RUN_ID") + ".json";
-            f = fullfile(testCase.TempFolder, name);
-            testCase.assertTrue(isfile(f));
+            f = findBuildSummaryFile(testCase.TempFolder);
+            testCase.assertTrue(~isempty(f));
 
             s = readstruct(f);
 
@@ -67,9 +69,8 @@ classdef tParallelizableBuildSummaryPlugin < matlab.unittest.TestCase
 
             testCase.Runner.run(plan, ["t1", "t2"]);
 
-            name = "buildSummary" + getenv("GITHUB_RUN_ID") + ".json";
-            f = fullfile(testCase.TempFolder, name);
-            testCase.assertTrue(isfile(f));
+            f = findBuildSummaryFile(testCase.TempFolder);
+            testCase.assertTrue(~isempty(f));
 
             s = readstruct(f);
 
@@ -88,10 +89,8 @@ classdef tParallelizableBuildSummaryPlugin < matlab.unittest.TestCase
 
             testCase.Runner.run(plan, "g:t");
 
-            name = "buildSummary" + getenv("GITHUB_RUN_ID") + ".json";
-            f = fullfile(testCase.TempFolder, name);
-
-            testCase.assertTrue(isfile(f));
+            f = findBuildSummaryFile(testCase.TempFolder);
+            testCase.assertTrue(~isempty(f));
 
             s = readstruct(f);
 
@@ -108,4 +107,13 @@ end
 
 function task = Task(varargin)
 task = matlab.buildtool.Task(varargin{:});
+end
+
+function f = findBuildSummaryFile(folder)
+files = dir(fullfile(folder, "buildSummary*.json"));
+if isempty(files)
+    f = "";
+else
+    f = fullfile(folder, files(1).name);
+end
 end


### PR DESCRIPTION
### Summary

  - Skip test results JSON artifact generation in `TestResultsSummaryPlugin` when `MW_GENERATE_JOB_SUMMARY` env var is `false`, allowing the caller action to disable job summary entirely
  - Skip build summary JSON artifact generation in `BuildSummaryPlugin` and `ParallelizableBuildSummaryPlugin` under the same condition.
  - Include `GITHUB_ACTION` and a timestamp in both artifact filenames (`matlabTestResults<actionName>_<timestamp>.json`, `buildSummary<actionName>_<timestamp>.json`) so each action step only reads its own artifacts.
  - Refactor unit tests to eliminate redundant helper definitions and add comprehensive tests for the new filtering and
  discovery logic

**NOTE:** Subsequent PRs will be created for `run-tests`, `run-command` and `run-build` action repos to add a new `generate-job-summary` input (defaults to true) that passes `MW_GENERATE_JOB_SUMMARY` as an environment variable, allowing users to opt out of CI job summary generation.