### PR TITLE
Move job summary opt-out check to plugin service classes

### DIFF
--- a/plugins/+buildframework/BuildSummaryPlugin.m
+++ b/plugins/+buildframework/BuildSummaryPlugin.m
@@ -10,15 +10,13 @@ classdef BuildSummaryPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
         function runTaskGraph(plugin, pluginData)
             runTaskGraph@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
 
-            if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true")
-                [fID, msg] = fopen(fullfile(getenv("RUNNER_TEMP"), "buildSummary" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json"), "w");
-                if fID == -1
-                    warning("buildframework:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
-                else
-                    closeFile = onCleanup(@()fclose(fID));
-                    s = jsonencode(plugin.TaskDetails);
-                    fprintf(fID, "%s",s);
-                end
+            [fID, msg] = fopen(fullfile(getenv("RUNNER_TEMP"), "buildSummary" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json"), "w");
+            if fID == -1
+                warning("buildframework:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
+            else
+                closeFile = onCleanup(@()fclose(fID));
+                s = jsonencode(plugin.TaskDetails);
+                fprintf(fID, "%s",s);
             end
         end
 

--- a/plugins/+buildframework/ParallelizableBuildSummaryPlugin.m
+++ b/plugins/+buildframework/ParallelizableBuildSummaryPlugin.m
@@ -34,16 +34,14 @@ classdef ParallelizableBuildSummaryPlugin < matlab.buildtool.plugins.BuildRunner
             end
 
             % Write to file
-            if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true")
-                folder = fileparts(plugin.TempFolder);
-                [fID, msg] = fopen(fullfile(folder, "buildSummary" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json"), "w");
-                if fID == -1
-                    warning("buildframework:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
-                else
-                    closeFile = onCleanup(@()fclose(fID));
-                    s = jsonencode(taskDetails);
-                    fprintf(fID, "%s", s);
-                end
+            folder = fileparts(plugin.TempFolder);
+            [fID, msg] = fopen(fullfile(folder, "buildSummary" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json"), "w");
+            if fID == -1
+                warning("buildframework:BuildSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the MATLAB build summary table: %s", msg);
+            else
+                closeFile = onCleanup(@()fclose(fID));
+                s = jsonencode(taskDetails);
+                fprintf(fID, "%s", s);
             end
         end
 

--- a/plugins/+buildframework/getDefaultPlugins.m
+++ b/plugins/+buildframework/getDefaultPlugins.m
@@ -6,15 +6,17 @@ arguments
     pluginProviderData (1,1) struct = struct();
 end
 
-if isMATLABReleaseOlderThan("R2026a")
-    reportPlugin = buildframework.BuildSummaryPlugin();
-else
-    reportPlugin = buildframework.ParallelizableBuildSummaryPlugin();
-end
-
 plugins = [ ...
     matlab.buildtool.internal.getFactoryDefaultPlugins(pluginProviderData) ...
     buildframework.GitHubLogPlugin() ...
-    reportPlugin ...
 ];
+
+if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true")
+    if isMATLABReleaseOlderThan("R2026a")
+        reportPlugin = buildframework.BuildSummaryPlugin();
+    else
+        reportPlugin = buildframework.ParallelizableBuildSummaryPlugin();
+    end
+    plugins = [plugins reportPlugin];
+end
 end

--- a/plugins/+buildframework/getDefaultPlugins.m
+++ b/plugins/+buildframework/getDefaultPlugins.m
@@ -11,7 +11,7 @@ plugins = [ ...
     buildframework.GitHubLogPlugin() ...
 ];
 
-if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true")
+if strcmpi(getenv("MW_GENERATE_SUMMARY"), "true")
     if isMATLABReleaseOlderThan("R2026a")
         reportPlugin = buildframework.BuildSummaryPlugin();
     else

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/TestResultsSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/TestResultsSummaryPluginService.m
@@ -4,7 +4,7 @@ classdef TestResultsSummaryPluginService < matlab.buildtool.internal.services.ci
     methods
         function plugins = providePlugins(~, ~)
             % Check if MATLAB Test license is available
-            if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true") && license('test', 'matlab_test')
+            if strcmpi(getenv("MW_GENERATE_SUMMARY"), "true") && license('test', 'matlab_test')
                 plugins = testframework.TestResultsSummaryPlugin();
             else
                 plugins = matlab.unittest.plugins.TestRunnerPlugin.empty(1,0);

--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/TestResultsSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/TestResultsSummaryPluginService.m
@@ -4,7 +4,7 @@ classdef TestResultsSummaryPluginService < matlab.buildtool.internal.services.ci
     methods
         function plugins = providePlugins(~, ~)
             % Check if MATLAB Test license is available
-            if license('test', 'matlab_test')
+            if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true") && license('test', 'matlab_test')
                 plugins = testframework.TestResultsSummaryPlugin();
             else
                 plugins = matlab.unittest.plugins.TestRunnerPlugin.empty(1,0);

--- a/plugins/+testframework/TestResultsSummaryPlugin.m
+++ b/plugins/+testframework/TestResultsSummaryPlugin.m
@@ -3,39 +3,37 @@ classdef TestResultsSummaryPlugin < matlab.unittest.plugins.TestRunnerPlugin
     
     methods (Access=protected)
         function reportFinalizedSuite(plugin, pluginData)
-            if strcmpi(getenv("MW_GENERATE_JOB_SUMMARY"), "true")
-                % Checkout MATLAB Test license
-                license('checkout', 'matlab_test');
+            % Checkout MATLAB Test license
+            license('checkout', 'matlab_test');
 
-                testDetails = struct([]);
-                for idx = 1:numel(pluginData.TestResult)
-                    testDetails(idx).TestResult.Duration = pluginData.TestResult(idx).Duration;
-                    if isfield(pluginData.TestResult(idx).Details, "DiagnosticRecord") && ~isempty(pluginData.TestResult(idx).Details.DiagnosticRecord)
-                        testDetails(idx).TestResult.Details.DiagnosticRecord.Event = pluginData.TestResult(idx).Details.DiagnosticRecord.Event;
-                        testDetails(idx).TestResult.Details.DiagnosticRecord.Report = pluginData.TestResult(idx).Details.DiagnosticRecord.Report;
-                    else
-                        testDetails(idx).TestResult.Details = struct();
-                    end
-                    testDetails(idx).TestResult.Name = pluginData.TestResult(idx).Name;
-                    testDetails(idx).TestResult.Passed = pluginData.TestResult(idx).Passed;
-                    testDetails(idx).TestResult.Failed = pluginData.TestResult(idx).Failed;
-                    testDetails(idx).TestResult.Incomplete = pluginData.TestResult(idx).Incomplete;
-                    testDetails(idx).BaseFolder = pluginData.TestSuite(idx).BaseFolder;
+            testDetails = struct([]);
+            for idx = 1:numel(pluginData.TestResult)
+                testDetails(idx).TestResult.Duration = pluginData.TestResult(idx).Duration;
+                if isfield(pluginData.TestResult(idx).Details, "DiagnosticRecord") && ~isempty(pluginData.TestResult(idx).Details.DiagnosticRecord)
+                    testDetails(idx).TestResult.Details.DiagnosticRecord.Event = pluginData.TestResult(idx).Details.DiagnosticRecord.Event;
+                    testDetails(idx).TestResult.Details.DiagnosticRecord.Report = pluginData.TestResult(idx).Details.DiagnosticRecord.Report;
+                else
+                    testDetails(idx).TestResult.Details = struct();
                 end
+                testDetails(idx).TestResult.Name = pluginData.TestResult(idx).Name;
+                testDetails(idx).TestResult.Passed = pluginData.TestResult(idx).Passed;
+                testDetails(idx).TestResult.Failed = pluginData.TestResult(idx).Failed;
+                testDetails(idx).TestResult.Incomplete = pluginData.TestResult(idx).Incomplete;
+                testDetails(idx).BaseFolder = pluginData.TestSuite(idx).BaseFolder;
+            end
 
-                try
-                    jsonTestResults = jsonencode(testDetails, "PrettyPrint", true);
-                    testArtifactFile = fullfile(getenv("RUNNER_TEMP"), "matlabTestResults" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json");
-                    [fID, msg] = fopen(testArtifactFile, "w");
-                    if fID == -1
-                        warning("testframework:TestResultsSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the table of test results. (Cause: %s)", msg);
-                    else
-                        closeFile = onCleanup(@()fclose(fID));
-                        fprintf(fID, '%s', jsonTestResults);
-                    end
-                catch e
-                    warning("testframework:TestResultsSummaryPlugin:UnableToJsonEncode","Unable to jsonencode test results data. (Cause: %s)", e.message);
+            try
+                jsonTestResults = jsonencode(testDetails, "PrettyPrint", true);
+                testArtifactFile = fullfile(getenv("RUNNER_TEMP"), "matlabTestResults" + getenv("GITHUB_ACTION") + "_" + string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS')) + ".json");
+                [fID, msg] = fopen(testArtifactFile, "w");
+                if fID == -1
+                    warning("testframework:TestResultsSummaryPlugin:UnableToOpenFile","Unable to open a file required to create the table of test results. (Cause: %s)", msg);
+                else
+                    closeFile = onCleanup(@()fclose(fID));
+                    fprintf(fID, '%s', jsonTestResults);
                 end
+            catch e
+                warning("testframework:TestResultsSummaryPlugin:UnableToJsonEncode","Unable to jsonencode test results data. (Cause: %s)", e.message);
             end
 
             % Invoke the superclass method

--- a/src/testResultsSummary.ts
+++ b/src/testResultsSummary.ts
@@ -86,11 +86,9 @@ export function getTestResults(
     actionName: string,
     workspace: string,
 ): TestResultsData | null {
-    let testResultsData = null;
     const filePrefix = `matlabTestResults${actionName}_`;
     const fileSuffix = `.json`;
 
-    // Find all test result files matching the pattern
     let testResultFiles: string[] = [];
     try {
         testResultFiles = readdirSync(runnerTemp)
@@ -118,12 +116,6 @@ export function getTestResults(
         Duration: 0,
     };
 
-    testResultsData = {
-        TestSessions: testSessions,
-        OverallStats: overallStats,
-    };
-
-    // Process each test result file
     for (const fileName of testResultFiles) {
         const resultsPath = path.join(runnerTemp, fileName);
 
@@ -140,21 +132,18 @@ export function getTestResults(
             };
 
             const map = new Map<string, MatlabTestFile>();
-
             const testCases = Array.isArray(testArtifact) ? testArtifact : [testArtifact];
 
             for (const jsonTestCase of testCases) {
                 processTestCase(sessionResults, jsonTestCase, map, sessionStats, workspace);
             }
 
-            // Add this session to the list
             testSessions.push({
                 FileName: fileName,
                 TestResults: sessionResults,
                 Stats: sessionStats,
             });
 
-            // Update overall stats
             overallStats.Total += sessionStats.Total;
             overallStats.Passed += sessionStats.Passed;
             overallStats.Failed += sessionStats.Failed;
@@ -178,7 +167,11 @@ export function getTestResults(
         }
     }
 
-    return testResultsData;
+    if (testSessions.length === 0) {
+        return null;
+    }
+
+    return { TestSessions: testSessions, OverallStats: overallStats };
 }
 export function addSummary(
     testResultsData: TestResultsData | null,

--- a/src/testResultsSummary.ts
+++ b/src/testResultsSummary.ts
@@ -89,6 +89,7 @@ export function getTestResults(
     const filePrefix = `matlabTestResults${actionName}_`;
     const fileSuffix = `.json`;
 
+    // Find all test result files matching the pattern
     let testResultFiles: string[] = [];
     try {
         testResultFiles = readdirSync(runnerTemp)

--- a/src/testResultsSummary.unit.test.ts
+++ b/src/testResultsSummary.unit.test.ts
@@ -653,9 +653,7 @@ describe("Error Handling Tests", () => {
 
         try {
             const result = testResultsSummary.getTestResults(runnerTemp, "", "");
-            expect(result).not.toBeNull();
-            expect(result!.TestSessions.length).toBe(0);
-            expect(result!.OverallStats.Total).toBe(0);
+            expect(result).toBeNull();
 
             expect(consoleSpy).toHaveBeenCalledWith(
                 expect.stringContaining(

--- a/tests/tParallelizableBuildSummaryPlugin.m
+++ b/tests/tParallelizableBuildSummaryPlugin.m
@@ -24,7 +24,7 @@ classdef tParallelizableBuildSummaryPlugin < matlab.unittest.TestCase
 
             testCase.applyFixture(WorkingFolderFixture);
             testCase.TempFolder = pwd();
-            testCase.applyFixture(EnvironmentVariableFixture("MW_GENERATE_JOB_SUMMARY", "true"));
+            testCase.applyFixture(EnvironmentVariableFixture("MW_GENERATE_SUMMARY", "true"));
             testCase.applyFixture(EnvironmentVariableFixture("GITHUB_ACTION", "my-action"));
 
             testCase.Plugin = ParallelizableBuildSummaryPlugin(TempFolder=testCase.TempFolder);


### PR DESCRIPTION
## Summary
  - Update `MW_GENERATE_JOB_SUMMARY` environment variable name to `MW_GENERATE_SUMMARY`
  - Move the `MW_GENERATE_SUMMARY` environment variable check from the plugin implementations to their respective service classes. When job summary is disabled, plugins are no longer instantiated rather than being instantiated and doing nothing

  ## Changes
  - `TestResultsSummaryPluginService.m` — guard plugin creation with `MW_GENERATE_SUMMARY` check
  - `getDefaultPlugins.m` — only add build summary plugin when `MW_GENERATE_SUMMARY` is `"true"`
  - `TestResultsSummaryPlugin.m` — removed env var check (plugin always generates artifacts when instantiated)
  - `BuildSummaryPlugin.m` — removed env var check
  - `ParallelizableBuildSummaryPlugin.m` — removed env var check
  - `testResultsSummary.unit.test.ts` — updated test to expect `null` on invalid JSON