### PR TITLE
Remove MATLAB Test license check

### DIFF
--- a/plugins/+matlab/+unittest/+internal/+services/+plugins/TestResultsSummaryPluginService.m
+++ b/plugins/+matlab/+unittest/+internal/+services/+plugins/TestResultsSummaryPluginService.m
@@ -3,8 +3,7 @@ classdef TestResultsSummaryPluginService < matlab.buildtool.internal.services.ci
 
     methods
         function plugins = providePlugins(~, ~)
-            % Check if MATLAB Test license is available
-            if strcmpi(getenv("MW_INPUT_GENERATE_SUMMARY"), "true") && license('test', 'matlab_test')
+            if strcmpi(getenv("MW_INPUT_GENERATE_SUMMARY"), "true")
                 plugins = testframework.TestResultsSummaryPlugin();
             else
                 plugins = matlab.unittest.plugins.TestRunnerPlugin.empty(1,0);

--- a/plugins/+testframework/TestResultsSummaryPlugin.m
+++ b/plugins/+testframework/TestResultsSummaryPlugin.m
@@ -3,9 +3,6 @@ classdef TestResultsSummaryPlugin < matlab.unittest.plugins.TestRunnerPlugin
     
     methods (Access=protected)
         function reportFinalizedSuite(plugin, pluginData)
-            % Checkout MATLAB Test license
-            license('checkout', 'matlab_test');
-
             testDetails = struct([]);
             for idx = 1:numel(pluginData.TestResult)
                 testDetails(idx).TestResult.Duration = pluginData.TestResult(idx).Duration;


### PR DESCRIPTION
### Summary

- Remove MATLAB Test license check and checkout, so the test results view feature is provided unconditionally