### PR TITLE
Use GitHub App token for publish workflow to bypass branch protection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,14 @@ jobs:
     outputs:
       tag: ${{ steps.update-package-version.outputs.version }}
     steps:
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Configure git
         run: |
           git config user.name 'Release Action'


### PR DESCRIPTION
Now that `main` is a protected branch, it is not possible to use the standard `GITHUB_TOKEN` to push back to it in the publish workflow. Instead, we need a GitHub App token because GitHub Apps can be added to the bypass list in the ruleset protecting the branch.